### PR TITLE
fix(reconciler): check terminal field in is_operator_stopped

### DIFF
--- a/.nwave/des-config.json
+++ b/.nwave/des-config.json
@@ -1,6 +1,6 @@
 {
   "update_check": {
-    "last_checked": "2026-05-12T06:45:59.865835+00:00",
+    "last_checked": "2026-05-13T14:40:21.113573+00:00",
     "skipped_versions": [],
     "frequency": "daily"
   },

--- a/crates/overdrive-core/src/reconciler.rs
+++ b/crates/overdrive-core/src/reconciler.rs
@@ -1569,7 +1569,8 @@ fn is_restartable(row: &AllocStatusRow) -> bool {
 
 /// True iff the alloc row represents a *natural exit* the Job-kind
 /// reconciler should finalize on — a terminal lifecycle state (Failed
-/// OR Terminated) whose `reason` is NOT an operator stop. Per
+/// OR Terminated) whose stop attribution (in either `terminal` or
+/// `reason`) is NOT an operator stop. Per
 /// ADR-0037 Amendment 2026-05-10 / ADR-0047 §1: Job kind terminates on
 /// the first observed exit (clean OR crashed). Operator-stopped rows
 /// are excluded — they are handled by the upstream

--- a/crates/overdrive-core/src/reconciler.rs
+++ b/crates/overdrive-core/src/reconciler.rs
@@ -1526,20 +1526,35 @@ fn mint_identity(workload_id: &WorkloadId, alloc_id: &AllocationId) -> SpiffeId 
 
 /// True iff the alloc row carries a terminal Operator-stop record.
 ///
-/// Per `fix-exec-driver-exit-watcher` Step 01-02 RCA §Bug 3: a row
-/// whose `reason` carries `Stopped { by: Operator }` is the terminal
-/// record of an intentional stop. The reconciler MUST NOT restart it
-/// or schedule a fresh allocation for the job — operator stop intent
-/// is the load-bearing discriminator and a fresh schedule would undo
-/// the operator's stop.
+/// Two writers produce operator-stop rows with different field shapes:
+///
+/// - **Exit observer** (direct observation): writes
+///   `reason: Stopped { by: Operator }`, `terminal: None`.
+/// - **Action shim** (ADR-0037 §4 SSOT): writes
+///   `reason: Stopped { by: Reconciler }`,
+///   `terminal: Stopped { by: Operator }`.
+///
+/// The function checks BOTH `terminal` (the ADR-0037 §4 SSOT) and
+/// `reason` (the exit-observer path) so that operator-stop rows from
+/// either writer are recognised. See GH #149 for the regression that
+/// motivated the dual check.
+///
+/// The reconciler MUST NOT restart or schedule a fresh allocation for
+/// an operator-stopped job — operator stop intent is the load-bearing
+/// discriminator and a fresh schedule would undo the operator's stop.
 fn is_operator_stopped(row: &AllocStatusRow) -> bool {
     row.state == AllocState::Terminated
-        && matches!(
+        && (matches!(
+            row.terminal,
+            Some(crate::transition_reason::TerminalCondition::Stopped {
+                by: crate::transition_reason::StoppedBy::Operator
+            })
+        ) || matches!(
             row.reason,
             Some(crate::transition_reason::TransitionReason::Stopped {
                 by: crate::transition_reason::StoppedBy::Operator
             })
-        )
+        ))
 }
 
 /// True iff the alloc row is a candidate for a `RestartAllocation`

--- a/crates/overdrive-core/tests/acceptance/workload_lifecycle_reconcile_branches.rs
+++ b/crates/overdrive-core/tests/acceptance/workload_lifecycle_reconcile_branches.rs
@@ -54,6 +54,7 @@ use overdrive_core::reconciler::{
 };
 use overdrive_core::traits::driver::Resources;
 use overdrive_core::traits::observation_store::{AllocState, AllocStatusRow, LogicalTimestamp};
+use overdrive_core::transition_reason::{StoppedBy, TerminalCondition, TransitionReason};
 
 // -------------------------------------------------------------------
 // fixtures
@@ -923,5 +924,62 @@ fn stop_branch_clears_last_failure_seen_at_when_no_running_allocs() {
          tick until `restart_counts` reaches RESTART_BACKOFF_CEILING. \
          Got last_failure_seen_at = {:?} (expected empty)",
         next_view.last_failure_seen_at,
+    );
+}
+
+// -------------------------------------------------------------------
+// GH #149 — `is_operator_stopped` must check `row.terminal` (ADR-0037 §4)
+// -------------------------------------------------------------------
+//
+// The action shim writes operator attribution to `row.terminal`, NOT
+// `row.reason`. `is_operator_stopped` previously only matched on
+// `row.reason`, so action-shim-produced Stop rows were invisible to
+// the operator-stop guard — the Run branch would emit a fresh
+// `StartAllocation` for an operator-stopped allocation, undoing the
+// operator's stop intent.
+
+/// Regression for GH #149: an alloc whose `terminal` field carries
+/// `Stopped { by: Operator }` (action-shim shape per ADR-0037 §4)
+/// must be recognised by `is_operator_stopped` even when `reason`
+/// carries `Stopped { by: Reconciler }` (the action shim's hard-coded
+/// reason). The Run branch must return empty actions — no
+/// `StartAllocation` for an operator-stopped allocation.
+#[test]
+fn run_branch_blocked_when_alloc_has_terminal_operator_stop() {
+    let nodes = one_node_map("local");
+
+    // Build an AllocStatusRow mimicking the action-shim output:
+    //   reason:   Stopped { by: Reconciler }  — action shim hard-codes this
+    //   terminal: Stopped { by: Operator }    — threaded from the action
+    let mut row = alloc_with_state("alloc-payments-0", "payments", "local", AllocState::Terminated);
+    row.reason = Some(TransitionReason::Stopped { by: StoppedBy::Reconciler });
+    row.terminal = Some(TerminalCondition::Stopped { by: StoppedBy::Operator });
+
+    let allocations = one_alloc_map("alloc-payments-0", row);
+
+    let desired = WorkloadLifecycleState {
+        job: Some(make_job("payments")),
+        desired_to_stop: false,
+        nodes: nodes.clone(),
+        allocations: BTreeMap::new(),
+        workload_kind: WorkloadKind::default(),
+    };
+    let actual = WorkloadLifecycleState {
+        job: Some(make_job("payments")),
+        desired_to_stop: false,
+        nodes,
+        allocations,
+        workload_kind: WorkloadKind::default(),
+    };
+    let view = WorkloadLifecycleView::default();
+    let tick = fresh_tick(Instant::now(), UnixInstant::from_unix_duration(Duration::from_secs(0)));
+
+    let r = WorkloadLifecycle::canonical();
+    let (actions, _next) = r.reconcile(&desired, &actual, &view, &tick);
+
+    assert!(
+        actions.is_empty(),
+        "Run branch must emit nothing for an operator-stopped alloc \
+         (terminal: Stopped {{ by: Operator }}); got {actions:?}",
     );
 }


### PR DESCRIPTION
## Summary

- `is_operator_stopped` now checks `row.terminal` (ADR-0037 §4 SSOT) **OR** `row.reason` (exit-observer path), instead of only `row.reason`
- After ADR-0037, the action shim writes operator-stop attribution to `terminal`, not `reason` — the old code returned `false` for every action-shim Stop row
- `is_restartable` and `is_natural_exit` are fixed transitively (both delegate to `is_operator_stopped`)

## Test plan

- [x] Regression test `run_branch_blocked_when_alloc_has_terminal_operator_stop` reproduces the exact action-shim row shape (`reason: Reconciler`, `terminal: Operator`) with no stop intent — confirmed RED before fix, GREEN after
- [x] All 927 tests in `rdeps(overdrive-core)` pass (lefthook pre-commit gate)
- [x] Clippy clean (`-D warnings`)
- [x] Doctests pass

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)