### PR TITLE
refactor(cli): rename internal job::submit surface to the deploy verb

### DIFF
--- a/.nwave/des-config.json
+++ b/.nwave/des-config.json
@@ -1,6 +1,6 @@
 {
   "update_check": {
-    "last_checked": "2026-06-03T07:58:55.615249+00:00",
+    "last_checked": "2026-06-04T14:09:12.658787+00:00",
     "skipped_versions": [],
     "frequency": "daily"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,16 +83,17 @@ top-level `Command::Deploy { spec, detach }` in
 the real command until commit `17f633e2` ("refactor: rename
 job-specific identifiers to workload-generic naming", May 11 2026),
 which promoted it to top-level `overdrive deploy`. The `Job` subcommand
-now carries only `list` and `stop`. The internal handler is still named
-`commands::job::submit` / `SubmitArgs` and there is a
-`tests/integration/job_submit.rs` — so the stale `job submit` phrasing
-is still discoverable in the code surface and keeps leaking into docs
-(it did in the udp-service-support DISCUSS/DIVERGE artifacts). When
-writing operator-facing docs, journeys, or examples, the only correct
-verb is `overdrive deploy <SPEC>`. Do not copy `job submit` from older
-phase docs or from the handler name. The internal-surface rename that
-removes this trap is tracked in
-[#193](https://github.com/overdrive-sh/overdrive/issues/193).
+now carries only `list` and `stop`. The internal handler surface was
+renamed to track the verb in #193: the module is
+`crates/overdrive-cli/src/commands/deploy.rs` (`commands::deploy`), the
+handlers are `deploy` / `deploy_streaming` (plus the per-workload-kind
+`deploy_streaming_job` / `deploy_streaming_service`), the arg/output
+types are `DeployArgs` / `DeployOutput` / `DeployStreamingOutput`, and
+the integration tests live in `tests/integration/deploy.rs`. No
+`job::submit` / `SubmitArgs` surface remains in the crate. When writing
+operator-facing docs, journeys, or examples, the only correct verb is
+`overdrive deploy <SPEC>`. Do not copy `job submit` from older phase
+docs.
 
 ## Mutation Testing Strategy
 

--- a/crates/overdrive-cli/CLAUDE.md
+++ b/crates/overdrive-cli/CLAUDE.md
@@ -30,7 +30,7 @@ trust triple `overdrive serve` writes already names the live
 endpoint. See `tests/integration/endpoint_from_config.rs` for the
 canonical shape.
 
-The transport-error tests in `tests/integration/job_submit.rs` are
+The transport-error tests in `tests/integration/deploy.rs` are
 the only exception — they overwrite the config's endpoint with an
 unreachable one (`127.0.0.1:1`) to exercise `CliError::Transport`.
 

--- a/crates/overdrive-cli/CLAUDE.md
+++ b/crates/overdrive-cli/CLAUDE.md
@@ -96,7 +96,7 @@ assert_eq!(output.spec_digest, expected_digest);
 ```rust
 // Bad — subprocess; rejected
 let out = Command::new(env!("CARGO_BIN_EXE_overdrive"))
-    .args(["job", "submit", "payments.toml"])
+    .args(["deploy", "payments.toml"])
     .output()?;
 assert!(out.status.success());
 ```

--- a/crates/overdrive-cli/CLAUDE.md
+++ b/crates/overdrive-cli/CLAUDE.md
@@ -13,9 +13,9 @@ not runtime-tunable per command.
 
 - `Cli` has no `endpoint` field — only `command`.
 - `ApiClient::from_config(config_path)` is the only constructor.
-- Handler arg structs (`SubmitArgs`, `StatusArgs`, `ListArgs`) carry
+- Handler arg structs (`DeployArgs`, `StatusArgs`, `ListArgs`) carry
   `config_path: PathBuf` — no endpoint field.
-- `SubmitOutput.endpoint` and the `CliError::Transport` rendering
+- `DeployOutput.endpoint` and the `CliError::Transport` rendering
   both read from `ApiClient::base_url()` — the endpoint the trust
   triple names is the only source.
 - `overdrive serve` writes the trust triple *after* binding the
@@ -84,8 +84,8 @@ in-memory config.
 
 ```rust
 // Good — direct call, injected sim adapters, typed assertion
-let output = overdrive_cli::commands::job::submit(
-    SubmitArgs { spec: spec_path, config_path: cfg_path },
+let output = overdrive_cli::commands::deploy::deploy(
+    DeployArgs { spec: spec_path, config_path: cfg_path },
     &SimClock::new(),
     &SimTransport::new(),
 ).await?;

--- a/crates/overdrive-cli/Cargo.toml
+++ b/crates/overdrive-cli/Cargo.toml
@@ -92,7 +92,7 @@ overdrive-control-plane.path = "../overdrive-control-plane"
 tempfile.workspace           = true
 base64.workspace             = true
 # Per ADR-0019 the operator config is TOML; the `toml` runtime dep
-# above covers both the `job submit` spec loader and the integration
+# above covers both the `deploy` spec loader and the integration
 # tests that round-trip the trust triple. No YAML serde backend
 # (`serde_yaml` / `serde_yml`) in this crate's dependency graph — the
 # absence is enforced by `cargo xtask yaml-free-cli` in CI (ADR-0019

--- a/crates/overdrive-cli/src/commands/cluster.rs
+++ b/crates/overdrive-cli/src/commands/cluster.rs
@@ -18,7 +18,7 @@
 //! issue #81 for reintroduction alongside `op create` / `op revoke`.
 //!
 //! `default_operator_config_dir` and `default_operator_config_path`
-//! remain — `serve` and `job submit` use them to compute the canonical
+//! remain — `serve` and `deploy` use them to compute the canonical
 //! read/write target for the trust triple.
 //!
 //! The handler is a plain `async fn` so integration tests can call it

--- a/crates/overdrive-cli/src/commands/deploy.rs
+++ b/crates/overdrive-cli/src/commands/deploy.rs
@@ -1,8 +1,8 @@
-//! `overdrive job submit`.
+//! `overdrive deploy <SPEC>`.
 //!
 //! Reads a TOML job spec from disk, runs `Job::from_submit` locally for
 //! fast-fail validation, POSTs the typed `SubmitWorkloadRequest` to the
-//! control plane, and returns a typed [`SubmitOutput`] carrying the
+//! control plane, and returns a typed [`DeployOutput`] carrying the
 //! `workload_id`, derived `intent_key`, canonical `spec_digest`, idempotency
 //! `outcome`, endpoint, and operator next-command hint.
 //!
@@ -108,7 +108,7 @@ impl StdoutTerminalProbe for RealStdoutTerminal {
 ///
 /// This is the SSOT for the dispatch decision — `main.rs` calls
 /// `should_stream(detach, probe.is_terminal())` and branches between
-/// `submit_streaming` (true) and `submit` (false). Acceptance tests
+/// `deploy_streaming` (true) and `deploy` (false). Acceptance tests
 /// at `tests/acceptance/submit_pipe_autodetect.rs` exercise this
 /// pure function directly; the wire-level Accept-header pinning is
 /// covered by the existing JSON-ack and streaming integration suites.
@@ -117,13 +117,13 @@ pub const fn should_stream(detach: bool, is_terminal: bool) -> bool {
     !detach && is_terminal
 }
 
-/// Arguments to [`submit`].
+/// Arguments to [`deploy`].
 ///
 /// `spec` is the path to a TOML file containing a `JobSpecInput`-shaped
 /// document; `config_path` locates the operator trust triple, which is
 /// the sole source of the control-plane endpoint per whitepaper §8.
 #[derive(Debug, Clone)]
-pub struct SubmitArgs {
+pub struct DeployArgs {
     /// Path to the TOML job spec on disk.
     pub spec: PathBuf,
     /// Path to the Talos-shape trust triple on disk. The endpoint
@@ -131,7 +131,7 @@ pub struct SubmitArgs {
     pub config_path: PathBuf,
 }
 
-/// Typed output of a successful `job submit`.
+/// Typed output of a successful `overdrive deploy`.
 ///
 /// Carries the server's assigned `workload_id`, the derived `intent_key`
 /// (`jobs/<id>`), the canonical `spec_digest`, the idempotency
@@ -145,7 +145,7 @@ pub struct SubmitArgs {
 /// Handlers never render output themselves; the binary wrapper passes
 /// this value to [`crate::render::workload_submit_accepted`].
 #[derive(Debug, Clone)]
-pub struct SubmitOutput {
+pub struct DeployOutput {
     /// Job ID echoed by the server — matches the `id` field of the
     /// input spec after validation.
     pub workload_id: String,
@@ -177,7 +177,7 @@ pub struct SubmitOutput {
 /// * [`CliError::Transport`] — the control plane is unreachable.
 /// * [`CliError::HttpStatus`] — the server returned 4xx / 5xx.
 /// * [`CliError::BodyDecode`] — the 2xx response body failed to parse.
-pub async fn submit(args: SubmitArgs) -> Result<SubmitOutput, CliError> {
+pub async fn deploy(args: DeployArgs) -> Result<DeployOutput, CliError> {
     // 1. Read TOML from disk. Missing / unreadable files map to
     //    InvalidSpec with field="spec" so the operator can fix the path.
     let toml_str = std::fs::read_to_string(&args.spec).map_err(|e| CliError::InvalidSpec {
@@ -186,11 +186,11 @@ pub async fn submit(args: SubmitArgs) -> Result<SubmitOutput, CliError> {
     })?;
 
     // 2. Try the kind-discriminated parser first (same detection as
-    //    `submit_streaming`). If the TOML carries a `[job]` section,
+    //    `deploy_streaming`). If the TOML carries a `[job]` section,
     //    translate to the wire shape via `JobSpecInput`. A `[service]`
     //    body (with `[[listener]]` blocks) routes to the Service-kind
     //    deploy lane below — this is the non-streaming (JSON-ack)
-    //    companion to `submit_streaming_service`, used by the detached /
+    //    companion to `deploy_streaming_service`, used by the detached /
     //    non-TTY `overdrive deploy` path (`main.rs` `Command::Deploy`).
     //    Flat TOMLs fall through to the legacy `JobSpecInput` parser.
     //    Per ADR-0051 the wire-side discriminator lives inside
@@ -216,7 +216,7 @@ pub async fn submit(args: SubmitArgs) -> Result<SubmitOutput, CliError> {
         // "missing field `id`" — the gap udp-service-support step 01-05
         // closes (the deploy half of S-04-A).
         Ok(WorkloadSpecInput::Service(service_spec)) => {
-            return submit_service(args, service_spec).await;
+            return deploy_service(args, service_spec).await;
         }
         // Slice 07 / US-07 — surface the kind-rejection verbatim with
         // its per-kind guidance. Without this explicit arm the error
@@ -254,7 +254,7 @@ pub async fn submit(args: SubmitArgs) -> Result<SubmitOutput, CliError> {
     let workload_id = parse_response_job_id(&resp.workload_id)?;
     let intent_key = IntentKey::for_workload(&workload_id).as_str().to_string();
     let next_command = format!("overdrive alloc status --job {}", resp.workload_id);
-    Ok(SubmitOutput {
+    Ok(DeployOutput {
         workload_id: resp.workload_id,
         intent_key,
         spec_digest: resp.spec_digest,
@@ -265,7 +265,7 @@ pub async fn submit(args: SubmitArgs) -> Result<SubmitOutput, CliError> {
 }
 
 /// Service-kind deploy in the JSON-ack (non-streaming) lane — the
-/// companion to [`submit_streaming_service`] for the detached / non-TTY
+/// companion to [`deploy_streaming_service`] for the detached / non-TTY
 /// `overdrive deploy` path.
 ///
 /// Projects the parser-side [`ServiceSpec`] (carries `Listener` with a
@@ -277,14 +277,14 @@ pub async fn submit(args: SubmitArgs) -> Result<SubmitOutput, CliError> {
 /// `Proto`, so the persisted `WorkloadIntent::Service(ServiceV1)`
 /// carries the operator's declared protocol verbatim.
 ///
-/// Returns the same [`SubmitOutput`] shape as the Job lane so the
+/// Returns the same [`DeployOutput`] shape as the Job lane so the
 /// caller renders `workload_submit_accepted` identically across kinds.
-async fn submit_service(
-    args: SubmitArgs,
+async fn deploy_service(
+    args: DeployArgs,
     service_spec: ServiceSpec,
-) -> Result<SubmitOutput, CliError> {
+) -> Result<DeployOutput, CliError> {
     // Project parser-side `ServiceSpec` → wire-side `ServiceSpecInput`,
-    // mirroring `submit_streaming_service`. The listener `(NonZeroU16,
+    // mirroring `deploy_streaming_service`. The listener `(NonZeroU16,
     // Proto)` pair projects to `(u16, String)`; the protocol's canonical
     // lowercase render (`Proto::as_str`) is what the server re-parses.
     let listeners: Vec<ListenerInput> = service_spec
@@ -323,7 +323,7 @@ async fn submit_service(
     let workload_id = parse_response_job_id(&resp.workload_id)?;
     let intent_key = IntentKey::for_workload(&workload_id).as_str().to_string();
     let next_command = format!("overdrive alloc status --job {}", resp.workload_id);
-    Ok(SubmitOutput {
+    Ok(DeployOutput {
         workload_id: resp.workload_id,
         intent_key,
         spec_digest: resp.spec_digest,
@@ -336,7 +336,7 @@ async fn submit_service(
 /// Parse a `workload_id` string echoed back in a successful 2xx control-plane
 /// response into a typed [`WorkloadId`].
 ///
-/// On `WorkloadId::new` failure, the call site at [`submit`] is *post-HTTP*:
+/// On `WorkloadId::new` failure, the call site at [`deploy`] is *post-HTTP*:
 /// the server returned a 200 OK whose `workload_id` field cannot be parsed by
 /// the same validating constructor the spec went through. Per the
 /// rustdoc on [`CliError::InvalidSpec`] (client-side spec validation
@@ -361,7 +361,7 @@ pub struct StopArgs {
     /// `WorkloadId::new` before any HTTP call so operators see the
     /// offending byte without a round-trip.
     pub id: String,
-    /// Path to the trust triple. Same conventions as [`SubmitArgs`].
+    /// Path to the trust triple. Same conventions as [`DeployArgs`].
     pub config_path: PathBuf,
 }
 
@@ -401,12 +401,12 @@ pub async fn stop(args: StopArgs) -> Result<StopOutput, CliError> {
 }
 
 // ---------------------------------------------------------------------------
-// `overdrive job submit` — streaming NDJSON consumer (Slice 02 step 02-04).
+// `overdrive deploy` — streaming NDJSON consumer (Slice 02 step 02-04).
 // ---------------------------------------------------------------------------
 
-/// Typed output of a successful streaming `job submit`.
+/// Typed output of a successful streaming `overdrive deploy`.
 ///
-/// Per slice 02 step 02-04 acceptance criteria, `submit_streaming`
+/// Per slice 02 step 02-04 acceptance criteria, `deploy_streaming`
 /// consumes the `application/x-ndjson` stream until a terminal
 /// `Succeeded` or `Failed` event arrives. The handler
 /// returns this typed shape carrying:
@@ -428,7 +428,7 @@ pub async fn stop(args: StopArgs) -> Result<StopOutput, CliError> {
 /// short-circuit BEFORE this struct is constructed and surface as
 /// `Err(CliError)` per [`crate::http_client::CliError`].
 #[derive(Debug, Clone)]
-pub struct SubmitStreamingOutput {
+pub struct DeployStreamingOutput {
     /// Job ID echoed by the server's `Accepted` event.
     pub workload_id: String,
     /// Derived intent-store key — `jobs/<workload_id>` per ADR-0011.
@@ -480,11 +480,11 @@ pub struct SubmitStreamingOutput {
 ///
 /// # Errors
 ///
-/// Same shapes as [`submit`] — pre-Accepted failures bubble up as
+/// Same shapes as [`deploy`] — pre-Accepted failures bubble up as
 /// [`CliError`] variants. Once `Accepted` arrives this function does
 /// not return `Err` for terminal failures: a `Failed` event
 /// is a successful termination of the stream that maps to a non-zero
-/// exit code via [`SubmitStreamingOutput::exit_code`].
+/// exit code via [`DeployStreamingOutput::exit_code`].
 ///
 /// # Panics
 ///
@@ -492,7 +492,7 @@ pub struct SubmitStreamingOutput {
 /// is unreachable — `from_config` returns `Err(CliError::ConfigLoad)`
 /// on URL-parse failure, never returning a client whose base URL is
 /// absent.
-pub async fn submit_streaming(args: SubmitArgs) -> Result<SubmitStreamingOutput, CliError> {
+pub async fn deploy_streaming(args: DeployArgs) -> Result<DeployStreamingOutput, CliError> {
     // 1. Read TOML from disk — same as the one-shot lane.
     let toml_str = std::fs::read_to_string(&args.spec).map_err(|e| CliError::InvalidSpec {
         field: "spec".to_string(),
@@ -505,16 +505,16 @@ pub async fn submit_streaming(args: SubmitArgs) -> Result<SubmitStreamingOutput,
     //    step 01-03e3-fix the dispatch is per-kind: each arm wraps its
     //    own typed payload into the matching `SubmitSpecInput::*` variant
     //    and routes to a per-kind streaming consumer (Job →
-    //    `submit_streaming_job` → `JobSubmitEvent` arms; Service →
-    //    `submit_streaming_service` → `ServiceSubmitEvent` arms). The
+    //    `deploy_streaming_job` → `JobSubmitEvent` arms; Service →
+    //    `deploy_streaming_service` → `ServiceSubmitEvent` arms). The
     //    legacy "fall through to flat `JobSpecInput` + wrap in
     //    `SubmitSpecInput::Job`" path was the gap that produced the
     //    cross-routing bug 01-03e3-fix closes: Service-kind TOML must
     //    NEVER be wrapped in `SubmitSpecInput::Job(_)`.
     match WorkloadSpecInput::from_toml_str(&toml_str) {
-        Ok(WorkloadSpecInput::Job(job_spec)) => submit_streaming_job(args, job_spec).await,
+        Ok(WorkloadSpecInput::Job(job_spec)) => deploy_streaming_job(args, job_spec).await,
         Ok(WorkloadSpecInput::Service(service_spec)) => {
-            submit_streaming_service(args, service_spec).await
+            deploy_streaming_service(args, service_spec).await
         }
         Ok(WorkloadSpecInput::Schedule(_)) => Err(CliError::InvalidSpec {
             field: "spec.kind".to_string(),
@@ -533,10 +533,10 @@ pub async fn submit_streaming(args: SubmitArgs) -> Result<SubmitStreamingOutput,
 /// terminal; the terminal verdict is `Succeeded` (exit 0) or
 /// `Failed` (non-zero exit code or backoff exhausted). The CLI
 /// process exit code equals the workload's kernel-observed exit code.
-async fn submit_streaming_job(
-    args: SubmitArgs,
+async fn deploy_streaming_job(
+    args: DeployArgs,
     job_spec: JobSpec,
-) -> Result<SubmitStreamingOutput, CliError> {
+) -> Result<DeployStreamingOutput, CliError> {
     // Translate the kind-discriminated `JobSpec` to the legacy
     // `JobSpecInput` wire shape the server's spec-ingest still
     // expects (server-side `WorkloadSpec` ingest is the next slice's
@@ -586,7 +586,7 @@ async fn submit_streaming_job(
 }
 
 /// Submit a Service-kind spec via the streaming NDJSON lane and consume
-/// to terminal. Mirrors [`submit_streaming_job`] for the Service kind
+/// to terminal. Mirrors [`deploy_streaming_job`] for the Service kind
 /// per ADR-0047 §3 [D2] / [D7] and step 01-03e3-fix: routes to the
 /// `ServiceSubmitEvent` consumer surface (`Accepted / Stable / Failed /
 /// Stopped`), NOT the `JobSubmitEvent` surface.
@@ -595,10 +595,10 @@ async fn submit_streaming_job(
 /// `NonZeroU16` port and `Proto` enum) to the wire-side
 /// [`ServiceSpecInput`] (carries `ListenerInput` with `u16` port and
 /// `String` protocol) and POSTs as `SubmitSpecInput::Service(_)`.
-async fn submit_streaming_service(
-    args: SubmitArgs,
+async fn deploy_streaming_service(
+    args: DeployArgs,
     service_spec: ServiceSpec,
-) -> Result<SubmitStreamingOutput, CliError> {
+) -> Result<DeployStreamingOutput, CliError> {
     // Project parser-side `ServiceSpec` → wire-side `ServiceSpecInput`.
     // The parser-side `Listener` carries `(NonZeroU16, Proto)`; the
     // wire-side `ListenerInput` carries `(u16, String)` for JSON
@@ -665,7 +665,7 @@ async fn consume_stream(
     response: reqwest::Response,
     endpoint: Url,
     validated_job_id: String,
-) -> Result<SubmitStreamingOutput, CliError> {
+) -> Result<DeployStreamingOutput, CliError> {
     use overdrive_control_plane::streaming::ServiceSubmitEvent;
 
     let mut stream = response.bytes_stream();
@@ -719,7 +719,7 @@ async fn consume_stream(
                         &witness,
                     );
                     let next_command = format!("overdrive alloc status --job {}", acc.workload_id);
-                    return Ok(SubmitStreamingOutput {
+                    return Ok(DeployStreamingOutput {
                         workload_id: acc.workload_id,
                         intent_key: acc.intent_key,
                         spec_digest: acc.spec_digest,
@@ -755,7 +755,7 @@ async fn consume_stream(
                         early_exit_timing,
                     );
                     let next_command = format!("overdrive alloc status --job {}", acc.workload_id);
-                    return Ok(SubmitStreamingOutput {
+                    return Ok(DeployStreamingOutput {
                         workload_id: acc.workload_id,
                         intent_key: acc.intent_key,
                         spec_digest: acc.spec_digest,
@@ -778,7 +778,7 @@ async fn consume_stream(
                         by,
                     );
                     let next_command = format!("overdrive alloc status --job {}", acc.workload_id);
-                    return Ok(SubmitStreamingOutput {
+                    return Ok(DeployStreamingOutput {
                         workload_id: acc.workload_id,
                         intent_key: acc.intent_key,
                         spec_digest: acc.spec_digest,
@@ -835,7 +835,7 @@ async fn consume_stream_job(
     endpoint: Url,
     validated_job_id: String,
     submit_echo: String,
-) -> Result<SubmitStreamingOutput, CliError> {
+) -> Result<DeployStreamingOutput, CliError> {
     let mut stream = response.bytes_stream();
     let mut buf = BytesMut::new();
     let stream_started = std::time::Instant::now();
@@ -921,7 +921,7 @@ async fn consume_stream_job(
                         attempts,
                     ));
                     let next_command = format!("overdrive alloc status --job {}", acc.workload_id);
-                    return Ok(SubmitStreamingOutput {
+                    return Ok(DeployStreamingOutput {
                         workload_id: acc.workload_id,
                         intent_key: acc.intent_key,
                         spec_digest: acc.spec_digest,
@@ -958,7 +958,7 @@ async fn consume_stream_job(
                         attempts,
                     ));
                     let next_command = format!("overdrive alloc status --job {}", acc.workload_id);
-                    return Ok(SubmitStreamingOutput {
+                    return Ok(DeployStreamingOutput {
                         workload_id: acc.workload_id,
                         intent_key: acc.intent_key,
                         spec_digest: acc.spec_digest,
@@ -991,7 +991,7 @@ async fn consume_stream_job(
                         &stderr_str,
                     ));
                     let next_command = format!("overdrive alloc status --job {}", acc.workload_id);
-                    return Ok(SubmitStreamingOutput {
+                    return Ok(DeployStreamingOutput {
                         workload_id: acc.workload_id,
                         intent_key: acc.intent_key,
                         spec_digest: acc.spec_digest,
@@ -1020,7 +1020,7 @@ async fn consume_stream_job(
 }
 
 /// Internal accumulator for the streaming `Accepted` event fields, used to
-/// build [`SubmitStreamingOutput`] when the terminal event arrives.
+/// build [`DeployStreamingOutput`] when the terminal event arrives.
 struct AcceptedFields {
     workload_id: String,
     intent_key: String,

--- a/crates/overdrive-cli/src/commands/mod.rs
+++ b/crates/overdrive-cli/src/commands/mod.rs
@@ -8,6 +8,6 @@
 
 pub mod alloc;
 pub mod cluster;
-pub mod job;
+pub mod deploy;
 pub mod node;
 pub mod serve;

--- a/crates/overdrive-cli/src/main.rs
+++ b/crates/overdrive-cli/src/main.rs
@@ -81,15 +81,15 @@ async fn run(cli: Cli) -> Result<()> {
             // `tests/acceptance/submit_pipe_autodetect.rs` exercises
             // it directly with fake probes.
             let config_path = default_config_path();
-            let args = overdrive_cli::commands::job::SubmitArgs { spec, config_path };
-            let probe = overdrive_cli::commands::job::RealStdoutTerminal;
-            let stream = overdrive_cli::commands::job::should_stream(
+            let args = overdrive_cli::commands::deploy::DeployArgs { spec, config_path };
+            let probe = overdrive_cli::commands::deploy::RealStdoutTerminal;
+            let stream = overdrive_cli::commands::deploy::should_stream(
                 detach,
-                overdrive_cli::commands::job::StdoutTerminalProbe::is_terminal(&probe),
+                overdrive_cli::commands::deploy::StdoutTerminalProbe::is_terminal(&probe),
             );
             if stream {
                 // Streaming-default lane — slice 02 step 02-04 shape.
-                match overdrive_cli::commands::job::submit_streaming(args).await {
+                match overdrive_cli::commands::deploy::deploy_streaming(args).await {
                     Ok(out) => {
                         // The streaming summary already includes the
                         // operator-facing block — print it verbatim.
@@ -119,7 +119,7 @@ async fn run(cli: Cli) -> Result<()> {
                 // Detached / non-TTY lane — JSON ack only, no NDJSON
                 // consumer engaged. Fires when `--detach` is set OR
                 // stdout is redirected (pipe / file / non-TTY).
-                match overdrive_cli::commands::job::submit(args).await {
+                match overdrive_cli::commands::deploy::deploy(args).await {
                     Ok(out) => {
                         print!("{}", overdrive_cli::render::workload_submit_accepted(&out));
                         // Exit code 0 on `Inserted`/`Unchanged` per the
@@ -138,8 +138,8 @@ async fn run(cli: Cli) -> Result<()> {
         }
         Command::Job(JobCommand::Stop { id }) => {
             let config_path = default_config_path();
-            let args = overdrive_cli::commands::job::StopArgs { id, config_path };
-            match overdrive_cli::commands::job::stop(args).await {
+            let args = overdrive_cli::commands::deploy::StopArgs { id, config_path };
+            match overdrive_cli::commands::deploy::stop(args).await {
                 Ok(out) => {
                     print!("{}", overdrive_cli::render::workload_stop_accepted(&out));
                     Ok(())

--- a/crates/overdrive-cli/src/render.rs
+++ b/crates/overdrive-cli/src/render.rs
@@ -34,7 +34,7 @@ pub mod schedule;
 
 use crate::commands::alloc::AllocStatusOutput;
 use crate::commands::cluster::ClusterStatusOutput;
-use crate::commands::job::{StopOutput, SubmitOutput};
+use crate::commands::deploy::{DeployOutput, StopOutput};
 use crate::commands::node::NodeListOutput;
 use crate::http_client::CliError;
 
@@ -110,7 +110,7 @@ pub fn node_list(out: &NodeListOutput) -> String {
 /// follow-up command so the operator can continue without consulting
 /// the docs.
 #[must_use]
-pub fn workload_submit_accepted(out: &SubmitOutput) -> String {
+pub fn workload_submit_accepted(out: &DeployOutput) -> String {
     use std::fmt::Write as _;
     let mut s = String::new();
     let _ = writeln!(s, "Accepted.");
@@ -374,7 +374,7 @@ pub fn cli_error(err: &CliError) -> String {
 /// outcomes (`Succeeded` / `Failed`) are emitted on the
 /// streaming success path and map to exit 0 / the workload's non-zero
 /// exit code respectively (see
-/// [`crate::commands::job::submit_streaming`]); they never flow through
+/// [`crate::commands::deploy::deploy_streaming`]); they never flow through
 /// this function.
 ///
 /// A non-zero streaming exit signals the workload reached the server

--- a/crates/overdrive-cli/src/render.rs
+++ b/crates/overdrive-cli/src/render.rs
@@ -803,7 +803,7 @@ pub fn alloc_status_kind_aware(out: &AllocStatusResponse) -> String {
         }
         WorkloadKind::Schedule => {
             // Schedule branch — minimal Phase-1 rendering. Slice 05
-            // (job_submit_schedule) provides the deferral surface;
+            // (deploy_schedule) provides the deferral surface;
             // here we name the kind so the dispatcher is exhaustive.
             let mut s = String::new();
             let _ = writeln!(s, "Schedule '{workload_name}' (kind: Schedule)");

--- a/crates/overdrive-cli/tests/acceptance/probes_kind_rejection_cli.rs
+++ b/crates/overdrive-cli/tests/acceptance/probes_kind_rejection_cli.rs
@@ -5,13 +5,13 @@
 //!
 //! Per `crates/overdrive-cli/CLAUDE.md`: tests call command handlers
 //! directly with injected adapters (NOT subprocess). The kind-
-//! rejection fires inside `job::submit` at spec-parse time, BEFORE any
+//! rejection fires inside `deploy::deploy` at spec-parse time, BEFORE any
 //! HTTP call (`ApiClient::from_config` is step 4; parse is step 2), so
 //! these tests need no running server — the `config_path` is never
 //! reached on the rejection path.
 //!
 //! Universe (observable surface of the driving port): the `Result`
-//! returned by `job::submit` — its `CliError` variant, the wrapped
+//! returned by `deploy::deploy` — its `CliError` variant, the wrapped
 //! `ParseError`'s `kind` / `guidance` fields, the rendered multi-line
 //! error string, and the `cli_error_to_exit_code` mapping. None of the
 //! assertions reach into handler internals.
@@ -27,7 +27,7 @@
 
 use std::path::PathBuf;
 
-use overdrive_cli::commands::job::{self, SubmitArgs};
+use overdrive_cli::commands::deploy::{self, DeployArgs};
 use overdrive_cli::http_client::CliError;
 use overdrive_cli::render::cli_error_to_exit_code;
 use overdrive_core::aggregate::{
@@ -104,7 +104,7 @@ port = 8080
 "#;
 
 /// S-SHCP-CLI-12 (US-07 / K5) — Job + `[[health_check.startup]]`
-/// submitted via the `job::submit` driving port returns
+/// submitted via the `deploy::deploy` driving port returns
 /// `CliError::ParseError(ProbesNotAllowedOnKind { kind: "job",
 /// guidance: <job guidance> })`, the rendered error contains the job
 /// guidance text, and the exit-code mapping is 1.
@@ -117,9 +117,9 @@ port = 8080
 #[tokio::test]
 async fn given_job_with_probe_section_when_submit_then_named_error_with_job_guidance_exit_one() {
     let (spec, _tmp) = write_fixture(JOB_WITH_STARTUP_PROBE);
-    let args = SubmitArgs { spec, config_path: PathBuf::from("/nonexistent/config") };
+    let args = DeployArgs { spec, config_path: PathBuf::from("/nonexistent/config") };
 
-    let err = job::submit(args).await.expect_err("Job + probe must be rejected");
+    let err = deploy::deploy(args).await.expect_err("Job + probe must be rejected");
     match &err {
         CliError::ParseError(ParseError::ProbesNotAllowedOnKind { kind, guidance }) => {
             assert_eq!(*kind, "job");
@@ -143,9 +143,9 @@ async fn given_job_with_probe_section_when_submit_then_named_error_with_job_guid
 #[tokio::test]
 async fn given_schedule_with_probe_section_when_submit_then_named_error_with_schedule_guidance() {
     let (spec, _tmp) = write_fixture(SCHEDULE_WITH_READINESS_PROBE);
-    let args = SubmitArgs { spec, config_path: PathBuf::from("/nonexistent/config") };
+    let args = DeployArgs { spec, config_path: PathBuf::from("/nonexistent/config") };
 
-    let err = job::submit(args).await.expect_err("Schedule + probe must be rejected");
+    let err = deploy::deploy(args).await.expect_err("Schedule + probe must be rejected");
     match &err {
         CliError::ParseError(ParseError::ProbesNotAllowedOnKind { kind, guidance }) => {
             assert_eq!(*kind, "schedule");
@@ -164,7 +164,7 @@ async fn given_schedule_with_probe_section_when_submit_then_named_error_with_sch
 /// `[[health_check.readiness]]` is ACCEPTED: the kind-discriminating
 /// parser does NOT raise `ProbesNotAllowedOnKind`. Asserted at the
 /// parse driving port (`WorkloadSpecInput::from_toml_str`) — a full
-/// `job::submit` would fall through to the legacy flat-`JobSpecInput`
+/// `deploy::deploy` would fall through to the legacy flat-`JobSpecInput`
 /// path and fail on the unrelated absence of flat job fields, which
 /// would conflate "kind rejection" with "wrong legacy shape". The
 /// regression this guards is precisely "Service probes must NOT trip

--- a/crates/overdrive-cli/tests/acceptance/render_workload_stop.rs
+++ b/crates/overdrive-cli/tests/acceptance/render_workload_stop.rs
@@ -14,7 +14,7 @@
 
 #![allow(clippy::expect_used)]
 
-use overdrive_cli::commands::job::StopOutput;
+use overdrive_cli::commands::deploy::StopOutput;
 use overdrive_control_plane::api::StopOutcome;
 use url::Url;
 

--- a/crates/overdrive-cli/tests/acceptance/render_workload_submit.rs
+++ b/crates/overdrive-cli/tests/acceptance/render_workload_submit.rs
@@ -18,15 +18,15 @@
 //!       token, and does NOT mention the removed `--endpoint` /
 //!       `OVERDRIVE_ENDPOINT` override surface.
 
-use overdrive_cli::commands::job::SubmitOutput;
+use overdrive_cli::commands::deploy::DeployOutput;
 use overdrive_cli::http_client::CliError;
 use overdrive_control_plane::api::IdempotencyOutcome;
 use url::Url;
 
 const FIXTURE_DIGEST: &str = "deadbeefcafebabe0123456789abcdefdeadbeefcafebabe0123456789abcdef";
 
-fn fixture_submit_output() -> SubmitOutput {
-    SubmitOutput {
+fn fixture_submit_output() -> DeployOutput {
+    DeployOutput {
         workload_id: "payments".to_string(),
         intent_key: "workloads/payments".to_string(),
         spec_digest: FIXTURE_DIGEST.to_string(),

--- a/crates/overdrive-cli/tests/acceptance/submit_detach_flag.rs
+++ b/crates/overdrive-cli/tests/acceptance/submit_detach_flag.rs
@@ -22,7 +22,7 @@
 //! header on the reqwest client, exit code 0 on `Inserted`, KPI-05
 //! wall-clock ≤ 200ms p95) is exercised by the integration suite that
 //! already covers the JSON-ack path
-//! (`tests/integration/job_submit.rs::submit_with_valid_toml_against_in_process_server_returns_submit_output_with_intent_key_and_next_command`)
+//! (`tests/integration/deploy.rs::submit_with_valid_toml_against_in_process_server_returns_submit_output_with_intent_key_and_next_command`)
 //! — the `--detach` flag dispatches to that same path through main.rs's
 //! match arm, so the existing JSON-path coverage is the wire-level
 //! witness.

--- a/crates/overdrive-cli/tests/acceptance/submit_pipe_autodetect.rs
+++ b/crates/overdrive-cli/tests/acceptance/submit_pipe_autodetect.rs
@@ -30,7 +30,7 @@
 //! boundary); Tier 1 wires fakes returning `false` (S-CLI-02) or `true`
 //! (S-CLI-06).
 
-use overdrive_cli::commands::job::{StdoutTerminalProbe, should_stream};
+use overdrive_cli::commands::deploy::{StdoutTerminalProbe, should_stream};
 
 // ---------------------------------------------------------------------
 // Fakes — the IsTerminal probe seam.
@@ -67,8 +67,8 @@ fn pipe_redirected_stdout_without_detach_selects_json_lane() {
     // Then: the dispatch decision is the JSON-ack lane (Detached).
     // The wire-level Accept-header pinning happens at
     // `ApiClient::submit_workload` (set to `application/json`); the
-    // `should_stream == false` branch causes main.rs to call `submit`
-    // (one-shot ack), not `submit_streaming`. The JSON-ack handler is
+    // `should_stream == false` branch causes main.rs to call `deploy`
+    // (one-shot ack), not `deploy_streaming`. The JSON-ack handler is
     // already exercised end-to-end by
     // `tests/integration/job_submit.rs::submit_with_valid_toml_against_in_process_server_returns_submit_output_with_intent_key_and_next_command`,
     // which is the wire witness for the `Accept: application/json`
@@ -98,7 +98,7 @@ fn tty_stdout_without_detach_selects_ndjson_lane() {
     // The wire-level Accept-header pinning happens at
     // `ApiClient::submit_workload_streaming` (set to `application/x-ndjson`);
     // the `should_stream == true` branch causes main.rs to call
-    // `submit_streaming` and engage the line-delimited consumer. The
+    // `deploy_streaming` and engage the line-delimited consumer. The
     // NDJSON handler is exercised end-to-end by
     // `tests/integration/streaming_submit_happy_path.rs` (Tier 3
     // Linux-gated).

--- a/crates/overdrive-cli/tests/acceptance/submit_pipe_autodetect.rs
+++ b/crates/overdrive-cli/tests/acceptance/submit_pipe_autodetect.rs
@@ -70,7 +70,7 @@ fn pipe_redirected_stdout_without_detach_selects_json_lane() {
     // `should_stream == false` branch causes main.rs to call `deploy`
     // (one-shot ack), not `deploy_streaming`. The JSON-ack handler is
     // already exercised end-to-end by
-    // `tests/integration/job_submit.rs::submit_with_valid_toml_against_in_process_server_returns_submit_output_with_intent_key_and_next_command`,
+    // `tests/integration/deploy.rs::submit_with_valid_toml_against_in_process_server_returns_submit_output_with_intent_key_and_next_command`,
     // which is the wire witness for the `Accept: application/json`
     // header path.
     assert!(

--- a/crates/overdrive-cli/tests/integration.rs
+++ b/crates/overdrive-cli/tests/integration.rs
@@ -23,13 +23,13 @@ mod integration {
 
     // udp-service-support step 01-05 — S-04-A driving-adapter companion:
     // `overdrive deploy <udp-spec>` accepted via the direct
-    // `commands::job::submit` handler; the persisted
+    // `commands::deploy::deploy` handler; the persisted
     // `WorkloadIntent::Service` intent carries `Proto::Udp` (C3 guard at
     // the spec → handler → intent boundary). Closes the deploy half of
     // S-04-A that step 01-03 (dataplane wire half) scoped out.
+    mod deploy;
     mod deploy_udp_walking_skeleton;
     mod http_client;
-    mod job_submit;
     mod post_http_invalid_job_id;
     mod walking_skeleton;
 
@@ -48,7 +48,7 @@ mod integration {
     // alloc-status render surface + IntentStore persistence, with
     // KPI K5 byte-equal deferral URL across surfaces. Per ADR-0047
     // §1, §3 + slice 05 spec.
-    mod job_submit_schedule;
+    mod deploy_schedule;
 
     // Slice 03 step 03-02 — S-CLI-03 Tier 3 jq-pipeline-equivalent:
     // a pipe-redirected stdout (non-TTY) without --detach MUST
@@ -91,8 +91,8 @@ mod integration {
 
     // service-health-check-probes step 01-03e3-fix — CLI submit-side
     // dispatch routing. Closes the gap 01-03e3 missed: a Service-kind
-    // TOML through `submit_streaming` must route to the new
-    // `submit_streaming_service` (the `ServiceSubmitEvent` consumer),
+    // TOML through `deploy_streaming` must route to the new
+    // `deploy_streaming_service` (the `ServiceSubmitEvent` consumer),
     // not fall through to the legacy `JobSpecInput` path.
     mod service_submit_streaming_cli_dispatch;
 }

--- a/crates/overdrive-cli/tests/integration/coinflip_honesty_100_trials.rs
+++ b/crates/overdrive-cli/tests/integration/coinflip_honesty_100_trials.rs
@@ -19,7 +19,7 @@
 //!
 //! Per `crates/overdrive-cli/CLAUDE.md` § *Integration tests — no
 //! subprocess*: the test calls
-//! `overdrive_cli::commands::deploy::submit_streaming` directly as a
+//! `overdrive_cli::commands::deploy::deploy_streaming` directly as a
 //! Rust async function. No `Command::spawn`.
 //!
 //! The `examples/coinflip.toml` workload picks a pseudo-random branch

--- a/crates/overdrive-cli/tests/integration/coinflip_honesty_100_trials.rs
+++ b/crates/overdrive-cli/tests/integration/coinflip_honesty_100_trials.rs
@@ -2,7 +2,7 @@
 //! gate).
 //!
 //! Per slice 02 step 02-07 of `workload-kind-discriminator`: 100 trials
-//! of `overdrive job submit examples/coinflip.toml` against the real
+//! of `overdrive deploy examples/coinflip.toml` against the real
 //! `ExecDriver` in Lima must show ≥99 trials where the CLI process
 //! exit code equals the workload's kernel-observed exit code AND every
 //! trial's terminal verdict line names the same exit code as the
@@ -19,7 +19,7 @@
 //!
 //! Per `crates/overdrive-cli/CLAUDE.md` § *Integration tests — no
 //! subprocess*: the test calls
-//! `overdrive_cli::commands::job::submit_streaming` directly as a
+//! `overdrive_cli::commands::deploy::submit_streaming` directly as a
 //! Rust async function. No `Command::spawn`.
 //!
 //! The `examples/coinflip.toml` workload picks a pseudo-random branch
@@ -58,7 +58,7 @@ use std::fmt::Write as _;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
-use overdrive_cli::commands::job::SubmitArgs;
+use overdrive_cli::commands::deploy::DeployArgs;
 use overdrive_cli::commands::serve::{ServeArgs, ServeHandle};
 use serial_test::serial;
 use tempfile::TempDir;
@@ -188,7 +188,7 @@ async fn s_02_09_k1_honesty_100_trials() {
         let spec_name = format!("coinflip-{trial:03}.toml");
         let spec_path = write_toml(tmp.path(), &spec_name, &body);
 
-        let output = overdrive_cli::commands::job::submit_streaming(SubmitArgs {
+        let output = overdrive_cli::commands::deploy::deploy_streaming(DeployArgs {
             spec: spec_path,
             config_path: cfg.clone(),
         })

--- a/crates/overdrive-cli/tests/integration/deploy.rs
+++ b/crates/overdrive-cli/tests/integration/deploy.rs
@@ -1,4 +1,4 @@
-//! Integration tests for `overdrive_cli::commands::deploy::submit` —
+//! Integration tests for `overdrive_cli::commands::deploy::deploy` —
 //! step 05-04.
 //!
 //! Per `crates/overdrive-cli/CLAUDE.md` these call the handler directly

--- a/crates/overdrive-cli/tests/integration/deploy.rs
+++ b/crates/overdrive-cli/tests/integration/deploy.rs
@@ -1,4 +1,4 @@
-//! Integration tests for `overdrive_cli::commands::job::submit` —
+//! Integration tests for `overdrive_cli::commands::deploy::submit` —
 //! step 05-04.
 //!
 //! Per `crates/overdrive-cli/CLAUDE.md` these call the handler directly
@@ -6,12 +6,12 @@
 //! `commands::serve::run(...)` (step 05-02), then the handler reads a
 //! TOML file from disk, validates locally through `Job::from_submit`
 //! (ADR-0011 constructor), POSTs `SubmitWorkloadRequest` via the `ApiClient`
-//! from step 05-01, and returns a typed `SubmitOutput` with `workload_id`,
+//! from step 05-01, and returns a typed `DeployOutput` with `workload_id`,
 //! `intent_key`, `spec_digest`, `outcome`, `endpoint`, and
 //! `next_command` (per ADR-0020 the `commit_index` field is dropped).
 //!
 //! Acceptance coverage:
-//!   (a) valid TOML against in-process server returns `SubmitOutput`
+//!   (a) valid TOML against in-process server returns `DeployOutput`
 //!       with `workload_id = "payments"`, `intent_key = "workloads/payments"`,
 //!       `outcome = IdempotencyOutcome::Inserted`, a 64-char
 //!       `spec_digest`, and `next_command` naming
@@ -31,7 +31,7 @@
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
-use overdrive_cli::commands::job::{SubmitArgs, SubmitOutput};
+use overdrive_cli::commands::deploy::{DeployArgs, DeployOutput};
 use overdrive_cli::commands::serve::{ServeArgs, ServeHandle};
 use overdrive_cli::http_client::CliError;
 use overdrive_control_plane::api::IdempotencyOutcome;
@@ -119,7 +119,7 @@ args = []
 }
 
 // -------------------------------------------------------------------
-// (a) submit with valid TOML against in-process server → SubmitOutput
+// (a) submit with valid TOML against in-process server → DeployOutput
 // -------------------------------------------------------------------
 
 #[tokio::test]
@@ -130,35 +130,35 @@ async fn submit_with_valid_toml_against_in_process_server_returns_submit_output_
 
     let spec_path = write_valid_payments_toml(tmp.path());
 
-    let args = SubmitArgs { spec: spec_path, config_path: cfg };
-    let output: SubmitOutput =
-        overdrive_cli::commands::job::submit(args).await.expect("job::submit");
+    let args = DeployArgs { spec: spec_path, config_path: cfg };
+    let output: DeployOutput =
+        overdrive_cli::commands::deploy::deploy(args).await.expect("deploy::deploy");
 
-    assert_eq!(output.workload_id, "payments", "SubmitOutput.workload_id must be 'payments'");
+    assert_eq!(output.workload_id, "payments", "DeployOutput.workload_id must be 'payments'");
     assert_eq!(
         output.intent_key, "workloads/payments",
-        "SubmitOutput.intent_key must be 'jobs/payments'",
+        "DeployOutput.intent_key must be 'jobs/payments'",
     );
     assert_eq!(
         output.outcome,
         IdempotencyOutcome::Inserted,
-        "SubmitOutput.outcome must be `Inserted` on a fresh submit; got {:?}",
+        "DeployOutput.outcome must be `Inserted` on a fresh submit; got {:?}",
         output.outcome,
     );
     assert_eq!(
         output.spec_digest.len(),
         64,
-        "SubmitOutput.spec_digest must be 64 hex chars (SHA-256); got {} chars",
+        "DeployOutput.spec_digest must be 64 hex chars (SHA-256); got {} chars",
         output.spec_digest.len(),
     );
     assert_eq!(
         output.endpoint,
         *handle.endpoint(),
-        "SubmitOutput.endpoint must echo the endpoint recorded in the operator config",
+        "DeployOutput.endpoint must echo the endpoint recorded in the operator config",
     );
     assert_eq!(
         output.next_command, "overdrive alloc status --job payments",
-        "SubmitOutput.next_command must guide the operator to alloc status",
+        "DeployOutput.next_command must guide the operator to alloc status",
     );
 
     handle.shutdown().await.expect("clean shutdown");
@@ -198,8 +198,8 @@ args = []
     let spec_path = tmp.path().join("broken.toml");
     std::fs::write(&spec_path, broken_spec).expect("write broken.toml");
 
-    let args = SubmitArgs { spec: spec_path, config_path: cfg };
-    let err = overdrive_cli::commands::job::submit(args)
+    let args = DeployArgs { spec: spec_path, config_path: cfg };
+    let err = overdrive_cli::commands::deploy::deploy(args)
         .await
         .expect_err("replicas=0 must fail local validation");
 
@@ -244,9 +244,9 @@ cpu_milli = 500
     let spec_path = tmp.path().join("broken_syntax.toml");
     std::fs::write(&spec_path, broken_syntax).expect("write broken_syntax.toml");
 
-    let args = SubmitArgs { spec: spec_path, config_path: cfg };
+    let args = DeployArgs { spec: spec_path, config_path: cfg };
     let err =
-        overdrive_cli::commands::job::submit(args).await.expect_err("malformed TOML must fail");
+        overdrive_cli::commands::deploy::deploy(args).await.expect_err("malformed TOML must fail");
 
     match &err {
         CliError::InvalidSpec { .. } => (),
@@ -272,8 +272,8 @@ async fn submit_against_unreachable_endpoint_returns_transport_error_naming_endp
 
     let spec_path = write_valid_payments_toml(tmp.path());
 
-    let args = SubmitArgs { spec: spec_path, config_path: cfg };
-    let err = overdrive_cli::commands::job::submit(args)
+    let args = DeployArgs { spec: spec_path, config_path: cfg };
+    let err = overdrive_cli::commands::deploy::deploy(args)
         .await
         .expect_err("unreachable endpoint must fail");
 
@@ -325,8 +325,8 @@ async fn submit_transport_error_display_does_not_contain_raw_reqwest_token() {
 
     let spec_path = write_valid_payments_toml(tmp.path());
 
-    let args = SubmitArgs { spec: spec_path, config_path: cfg };
-    let err = overdrive_cli::commands::job::submit(args)
+    let args = DeployArgs { spec: spec_path, config_path: cfg };
+    let err = overdrive_cli::commands::deploy::deploy(args)
         .await
         .expect_err("unreachable endpoint must fail");
 
@@ -392,8 +392,8 @@ async fn cli_submit_rejects_empty_exec_command_before_any_http_call() {
     let spec_path = tmp.path().join("empty-cmd.toml");
     std::fs::write(&spec_path, EMPTY_COMMAND_TOML).expect("write toml");
 
-    let args = SubmitArgs { spec: spec_path, config_path: cfg };
-    let err = overdrive_cli::commands::job::submit(args)
+    let args = DeployArgs { spec: spec_path, config_path: cfg };
+    let err = overdrive_cli::commands::deploy::deploy(args)
         .await
         .expect_err("empty exec.command must be rejected client-side");
 
@@ -424,7 +424,7 @@ async fn cli_submit_surfaces_missing_exec_table_as_toml_field_error() {
     // A TOML missing the `[exec]` table fails at `toml::from_str` —
     // before `Job::from_submit` runs. The CLI's existing mapping wraps
     // this as `CliError::InvalidSpec { field: "toml", .. }` (per
-    // `commands/job.rs:104-108`). Pin that the new tagged-enum
+    // `commands/deploy.rs:104-108`). Pin that the new tagged-enum
     // dispatch participates correctly: the absence of the driver
     // table is a parse-time rejection, not a runtime "missing field"
     // panic.
@@ -435,8 +435,8 @@ async fn cli_submit_surfaces_missing_exec_table_as_toml_field_error() {
     let spec_path = tmp.path().join("no-exec.toml");
     std::fs::write(&spec_path, MISSING_EXEC_TABLE_TOML).expect("write toml");
 
-    let args = SubmitArgs { spec: spec_path, config_path: cfg };
-    let err = overdrive_cli::commands::job::submit(args)
+    let args = DeployArgs { spec: spec_path, config_path: cfg };
+    let err = overdrive_cli::commands::deploy::deploy(args)
         .await
         .expect_err("TOML missing [exec] must be rejected at parse time");
 
@@ -444,7 +444,7 @@ async fn cli_submit_surfaces_missing_exec_table_as_toml_field_error() {
         CliError::InvalidSpec { field, message } => {
             assert_eq!(
                 field, "toml",
-                "TOML parse failures map to field=\"toml\" per commands/job.rs; got {field:?}",
+                "TOML parse failures map to field=\"toml\" per commands/deploy.rs; got {field:?}",
             );
             assert!(
                 message.contains("exec")
@@ -485,8 +485,8 @@ memory_bytes = 67108864
     let path = tmp.path().join("job-section.toml");
     std::fs::write(&path, spec).expect("write job-section.toml");
 
-    let args = SubmitArgs { spec: path, config_path: cfg };
-    let output: SubmitOutput = overdrive_cli::commands::job::submit(args)
+    let args = DeployArgs { spec: path, config_path: cfg };
+    let output: DeployOutput = overdrive_cli::commands::deploy::deploy(args)
         .await
         .expect("submit must accept [job]-section TOML");
 

--- a/crates/overdrive-cli/tests/integration/deploy_schedule.rs
+++ b/crates/overdrive-cli/tests/integration/deploy_schedule.rs
@@ -25,12 +25,12 @@
 //! # Sequencing note
 //!
 //! The slice 05 surface is render-side + `IntentStore`-side. The
-//! production `submit_streaming` parser is still legacy
+//! production `deploy_streaming` parser is still legacy
 //! `JobSpecInput`; slice 02 wires the `WorkloadSpec` discriminator
-//! into `submit_streaming`. These tests therefore exercise the slice
+//! into `deploy_streaming`. These tests therefore exercise the slice
 //! 05 surfaces directly (render functions, `IntentKey` derivation,
 //! `IntentStore` persistence helper) — not the legacy
-//! `submit_streaming` path. The matching slice-02 wiring covers the
+//! `deploy_streaming` path. The matching slice-02 wiring covers the
 //! end-to-end CLI flow later.
 
 use overdrive_cli::render::schedule::{
@@ -231,7 +231,7 @@ cron = "0 2 * * *"
 /// operator-supplied cron expression.
 ///
 /// Slice 05 ships the persistence helper at the `IntentStore`
-/// boundary; slice 02 wires it through `submit_streaming`. This
+/// boundary; slice 02 wires it through `deploy_streaming`. This
 /// test asserts the persistence-side contract directly.
 #[tokio::test]
 async fn schedule_05_05_schedule_submit_persists_to_intent_store() {

--- a/crates/overdrive-cli/tests/integration/deploy_udp_walking_skeleton.rs
+++ b/crates/overdrive-cli/tests/integration/deploy_udp_walking_skeleton.rs
@@ -4,10 +4,10 @@
 //!
 //! Per `crates/overdrive-cli/CLAUDE.md` § *Integration tests — no
 //! subprocess*: this test calls
-//! `overdrive_cli::commands::job::submit(SubmitArgs { ... })` directly
+//! `overdrive_cli::commands::deploy::deploy(DeployArgs { ... })` directly
 //! as a Rust async function — the in-process handler behind
 //! `overdrive deploy <SPEC>` in the detached / non-TTY (JSON-ack) lane
-//! (`main.rs` `Command::Deploy` → `commands::job::submit` →
+//! (`main.rs` `Command::Deploy` → `commands::deploy::submit` →
 //! `render::workload_submit_accepted`). NO
 //! `Command::new(env!("CARGO_BIN_EXE_overdrive"))`.
 //!
@@ -37,7 +37,7 @@
 //! the driving-adapter mirror of 01-01's intent→hydrator C3 guard. If
 //! the call site that wires the listener protocol through to the
 //! persisted intent were reverted (e.g. dropping the Service arm in
-//! `submit`, or hard-coding `Proto::Tcp`), this test goes RED.
+//! `deploy`, or hard-coding `Proto::Tcp`), this test goes RED.
 //!
 //! Together with 01-03's dataplane wire half (`REVERSE_NAT_MAP` dump +
 //! VIP-sourced reply) this closes the full S-04-A walking-skeleton
@@ -47,7 +47,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use overdrive_cli::commands::job::SubmitArgs;
+use overdrive_cli::commands::deploy::DeployArgs;
 use overdrive_cli::commands::serve::{ServeArgs, ServeHandle};
 use overdrive_control_plane::api::IdempotencyOutcome;
 use overdrive_core::aggregate::{IntentKey, WorkloadIntent};
@@ -122,12 +122,12 @@ async fn deploy_udp_service_is_accepted_and_persisted_intent_carries_proto_udp()
     // via the direct handler (the JSON-ack lane behind
     // `overdrive deploy <SPEC>`).
     let spec_path = write_toml(server_tmp.path(), "dns-resolver.toml", dns_resolver_udp_toml());
-    let submit_output = overdrive_cli::commands::job::submit(SubmitArgs {
+    let submit_output = overdrive_cli::commands::deploy::deploy(DeployArgs {
         spec: spec_path,
         config_path: server_cfg.clone(),
     })
     .await
-    .expect("job::submit must accept the single-UDP-listener Service spec end-to-end");
+    .expect("deploy::deploy must accept the single-UDP-listener Service spec end-to-end");
 
     // Phase 2 — AC #1: the deploy is accepted and renders the
     // `workload_submit_accepted` shape ("Accepted."). This is exactly

--- a/crates/overdrive-cli/tests/integration/deploy_udp_walking_skeleton.rs
+++ b/crates/overdrive-cli/tests/integration/deploy_udp_walking_skeleton.rs
@@ -7,7 +7,7 @@
 //! `overdrive_cli::commands::deploy::deploy(DeployArgs { ... })` directly
 //! as a Rust async function — the in-process handler behind
 //! `overdrive deploy <SPEC>` in the detached / non-TTY (JSON-ack) lane
-//! (`main.rs` `Command::Deploy` → `commands::deploy::submit` →
+//! (`main.rs` `Command::Deploy` → `commands::deploy::deploy` →
 //! `render::workload_submit_accepted`). NO
 //! `Command::new(env!("CARGO_BIN_EXE_overdrive"))`.
 //!

--- a/crates/overdrive-cli/tests/integration/endpoint_from_config.rs
+++ b/crates/overdrive-cli/tests/integration/endpoint_from_config.rs
@@ -14,7 +14,7 @@
 //!
 //! This test pins that contract: stand up a real in-process TLS server
 //! on an ephemeral port, rewrite the operator config so its `endpoint`
-//! field names that ephemeral port, invoke `job::submit` without any
+//! field names that ephemeral port, invoke `deploy::deploy` without any
 //! endpoint argument (because the field no longer exists), and assert
 //! the POST reaches the server — proving the client read the endpoint
 //! from the config rather than from a hardcoded default.
@@ -25,7 +25,7 @@
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
-use overdrive_cli::commands::job::{SubmitArgs, SubmitOutput};
+use overdrive_cli::commands::deploy::{DeployArgs, DeployOutput};
 use overdrive_cli::commands::serve::{ServeArgs, ServeHandle};
 use overdrive_control_plane::api::IdempotencyOutcome;
 use tempfile::TempDir;
@@ -80,7 +80,7 @@ args = []
     path
 }
 
-/// When the operator config names the server's endpoint, `job::submit`
+/// When the operator config names the server's endpoint, `deploy::deploy`
 /// — invoked WITHOUT any endpoint argument — reads that endpoint from
 /// the config and the POST reaches the server.
 ///
@@ -94,25 +94,25 @@ async fn job_submit_reads_endpoint_from_config_when_no_override_is_provided() {
     let cfg = config_path(tmp.path());
 
     let spec_path = write_valid_payments_toml(tmp.path());
-    let args = SubmitArgs { spec: spec_path, config_path: cfg };
+    let args = DeployArgs { spec: spec_path, config_path: cfg };
 
-    let output: SubmitOutput =
-        overdrive_cli::commands::job::submit(args).await.expect("job::submit");
+    let output: DeployOutput =
+        overdrive_cli::commands::deploy::deploy(args).await.expect("deploy::deploy");
 
     // The POST reached the server: the server assigned `workload_id`
     // `payments` and a fresh-insert outcome (per ADR-0020 the
     // per-write witness is `outcome` + `spec_digest`).
-    assert_eq!(output.workload_id, "payments", "SubmitOutput.workload_id must be 'payments'");
+    assert_eq!(output.workload_id, "payments", "DeployOutput.workload_id must be 'payments'");
     assert_eq!(
         output.outcome,
         IdempotencyOutcome::Inserted,
-        "SubmitOutput.outcome must be `Inserted` on a fresh submit; got {:?}",
+        "DeployOutput.outcome must be `Inserted` on a fresh submit; got {:?}",
         output.outcome,
     );
     assert_eq!(
         output.spec_digest.len(),
         64,
-        "SubmitOutput.spec_digest must be 64 hex chars (SHA-256); got {} chars",
+        "DeployOutput.spec_digest must be 64 hex chars (SHA-256); got {} chars",
         output.spec_digest.len(),
     );
 
@@ -123,7 +123,7 @@ async fn job_submit_reads_endpoint_from_config_when_no_override_is_provided() {
     assert_eq!(
         output.endpoint,
         *handle.endpoint(),
-        "SubmitOutput.endpoint must echo the endpoint recorded in the operator config",
+        "DeployOutput.endpoint must echo the endpoint recorded in the operator config",
     );
 
     handle.shutdown().await.expect("clean shutdown");

--- a/crates/overdrive-cli/tests/integration/exec_spec_walking_skeleton.rs
+++ b/crates/overdrive-cli/tests/integration/exec_spec_walking_skeleton.rs
@@ -3,7 +3,7 @@
 //!
 //! Per `crates/overdrive-cli/CLAUDE.md` § *Integration tests — no
 //! subprocess*: this test calls
-//! `overdrive_cli::commands::job::submit(SubmitArgs { ... })` directly
+//! `overdrive_cli::commands::deploy::deploy(DeployArgs { ... })` directly
 //! as a Rust async function. No `Command::new(env!("CARGO_BIN_EXE_overdrive"))`.
 //!
 //! The WS exercises the end-to-end data flow exposed in ADR-0031 §10:
@@ -40,7 +40,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use overdrive_cli::commands::job::SubmitArgs;
+use overdrive_cli::commands::deploy::DeployArgs;
 use overdrive_cli::commands::serve::{ServeArgs, ServeHandle};
 use overdrive_control_plane::api::IdempotencyOutcome;
 use overdrive_core::aggregate::{IntentKey, Job, JobSpecInput, WorkloadDriver};
@@ -120,12 +120,12 @@ async fn walking_skeleton_submit_with_exec_block_returns_inserted_and_persists_c
 
     // Phase 1 — write the new-shape TOML and submit via handler.
     let spec_path = write_toml(server_tmp.path(), "payments.toml", payments_toml_with_exec_block());
-    let submit_output = overdrive_cli::commands::job::submit(SubmitArgs {
+    let submit_output = overdrive_cli::commands::deploy::deploy(DeployArgs {
         spec: spec_path,
         config_path: server_cfg.clone(),
     })
     .await
-    .expect("job::submit must accept the new-shape spec end-to-end");
+    .expect("deploy::deploy must accept the new-shape spec end-to-end");
 
     // Phase 2 — assert the client-visible outcome.
     assert_eq!(submit_output.workload_id, "payments", "echoed workload_id must equal the spec id");

--- a/crates/overdrive-cli/tests/integration/job_kind_streaming.rs
+++ b/crates/overdrive-cli/tests/integration/job_kind_streaming.rs
@@ -30,7 +30,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use overdrive_cli::commands::alloc::StatusArgs as AllocStatusArgs;
-use overdrive_cli::commands::job::{StopArgs, SubmitArgs};
+use overdrive_cli::commands::deploy::{DeployArgs, StopArgs};
 use overdrive_cli::commands::serve::{ServeArgs, ServeHandle};
 use overdrive_control_plane::api::AllocStateWire;
 use serial_test::serial;
@@ -126,7 +126,7 @@ memory_bytes = 67108864
 /// parser AND the legacy `format_running_summary` Service-vocabulary
 /// renderer, which by construction emits `"is running with"`.
 ///
-/// Slice 02 (this step) wires `WorkloadSpec` into `submit_streaming`
+/// Slice 02 (this step) wires `WorkloadSpec` into `deploy_streaming`
 /// so a `[job]`-shape spec dispatches via `JobSubmitEvent` (no
 /// converged-running terminal variant) and renders via the new
 /// `format_job_succeeded_summary` whose output names exit code +
@@ -149,14 +149,14 @@ async fn s_02_05_anti_scenario_no_is_running_with() {
     let submit_cfg = cfg.clone();
     let stop_cfg = cfg.clone();
     let submit_handle = tokio::spawn(async move {
-        overdrive_cli::commands::job::submit_streaming(SubmitArgs {
+        overdrive_cli::commands::deploy::deploy_streaming(DeployArgs {
             spec: spec_path,
             config_path: submit_cfg,
         })
         .await
     });
     wait_for_alloc_running(&cfg, "happy-job").await;
-    let _ = overdrive_cli::commands::job::stop(StopArgs {
+    let _ = overdrive_cli::commands::deploy::stop(StopArgs {
         id: "happy-job".to_owned(),
         config_path: stop_cfg,
     })
@@ -217,14 +217,14 @@ async fn s_02_06_submit_echo_names_kind_upfront() {
     let submit_cfg = cfg.clone();
     let stop_cfg = cfg.clone();
     let submit_handle = tokio::spawn(async move {
-        overdrive_cli::commands::job::submit_streaming(SubmitArgs {
+        overdrive_cli::commands::deploy::deploy_streaming(DeployArgs {
             spec: spec_path,
             config_path: submit_cfg,
         })
         .await
     });
     wait_for_alloc_running(&cfg, "happy-job").await;
-    let _ = overdrive_cli::commands::job::stop(StopArgs {
+    let _ = overdrive_cli::commands::deploy::stop(StopArgs {
         id: "happy-job".to_owned(),
         config_path: stop_cfg,
     })
@@ -305,7 +305,7 @@ async fn s_02_01_job_exits_zero_reports_succeeded() {
 
     let spec_path = write_toml(tmp.path(), "happy-job.toml", job_exit_zero_spec());
 
-    let output = overdrive_cli::commands::job::submit_streaming(SubmitArgs {
+    let output = overdrive_cli::commands::deploy::deploy_streaming(DeployArgs {
         spec: spec_path,
         config_path: cfg,
     })
@@ -344,7 +344,7 @@ async fn s_02_02_job_exits_nonzero_reports_failed_with_attempts() {
 
     let spec_path = write_toml(tmp.path(), "coinflip.toml", job_exit_nonzero_spec());
 
-    let output = overdrive_cli::commands::job::submit_streaming(SubmitArgs {
+    let output = overdrive_cli::commands::deploy::deploy_streaming(DeployArgs {
         spec: spec_path,
         config_path: cfg,
     })
@@ -394,7 +394,7 @@ async fn s_02_03_intermediate_attempt_failure_does_not_close_stream() {
 
     let spec_path = write_toml(tmp.path(), "coinflip.toml", job_exit_nonzero_spec());
 
-    let output = overdrive_cli::commands::job::submit_streaming(SubmitArgs {
+    let output = overdrive_cli::commands::deploy::deploy_streaming(DeployArgs {
         spec: spec_path,
         config_path: cfg,
     })
@@ -436,7 +436,7 @@ async fn s_02_04_third_attempt_zero_reports_succeeded() {
 
     let spec_path = write_toml(tmp.path(), "happy-job.toml", job_exit_zero_spec());
 
-    let output = overdrive_cli::commands::job::submit_streaming(SubmitArgs {
+    let output = overdrive_cli::commands::deploy::deploy_streaming(DeployArgs {
         spec: spec_path,
         config_path: cfg,
     })
@@ -492,7 +492,7 @@ memory_bytes = 67108864
 "#;
     let spec_path = write_toml(tmp.path(), "bad-job.toml", bad_spec);
 
-    let err = overdrive_cli::commands::job::submit_streaming(SubmitArgs {
+    let err = overdrive_cli::commands::deploy::deploy_streaming(DeployArgs {
         spec: spec_path,
         config_path: cfg,
     })
@@ -540,7 +540,7 @@ async fn s_02_08_streaming_transport_interruption_surfaces_honestly() {
 
     let spec_path = write_toml(tmp.path(), "happy-job.toml", job_exit_zero_spec());
 
-    let err = overdrive_cli::commands::job::submit_streaming(SubmitArgs {
+    let err = overdrive_cli::commands::deploy::deploy_streaming(DeployArgs {
         spec: spec_path,
         config_path: cfg,
     })

--- a/crates/overdrive-cli/tests/integration/post_http_invalid_job_id.rs
+++ b/crates/overdrive-cli/tests/integration/post_http_invalid_job_id.rs
@@ -5,7 +5,7 @@
 //! [`WorkloadId::new`](overdrive_core::id::WorkloadId::new) constructor rejects.
 //!
 //! Bug under regression. The handler at
-//! `crates/overdrive-cli/src/commands/job.rs:110` was mapping post-HTTP
+//! `crates/overdrive-cli/src/commands/deploy.rs:110` was mapping post-HTTP
 //! `WorkloadId::new` failure to [`CliError::InvalidSpec`] — but per the rustdoc
 //! on the variants in `crates/overdrive-cli/src/http_client.rs:39-88`:
 //!
@@ -34,7 +34,7 @@
 //! end-to-end shape would. The mutation-testing gate at the per-file level
 //! still sees this as the canonical test for the variant choice.
 
-use overdrive_cli::commands::job::parse_response_job_id;
+use overdrive_cli::commands::deploy::parse_response_job_id;
 use overdrive_cli::http_client::CliError;
 
 /// A `workload_id` value that is JSON-decodable (it is just a `String`) but

--- a/crates/overdrive-cli/tests/integration/service_honest_stable.rs
+++ b/crates/overdrive-cli/tests/integration/service_honest_stable.rs
@@ -101,7 +101,7 @@ async fn submit_service_and_collect_events(
     };
 
     // Project parser-side `ServiceSpec` → wire-side `ServiceSpecInput`,
-    // mirroring `commands::deploy::submit_streaming_service`. The wire
+    // mirroring `commands::deploy::deploy_streaming_service`. The wire
     // shape preserves probe descriptors verbatim (including the
     // ADR-0058 default-TCP probe synthesised at parse time when the
     // TOML omits `[[health_check.startup]]`).

--- a/crates/overdrive-cli/tests/integration/service_honest_stable.rs
+++ b/crates/overdrive-cli/tests/integration/service_honest_stable.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 use bytes::BytesMut;
 use futures::StreamExt as _;
 use overdrive_cli::commands::cluster::StatusArgs as ClusterStatusArgs;
-use overdrive_cli::commands::job::StopArgs;
+use overdrive_cli::commands::deploy::StopArgs;
 use overdrive_cli::commands::serve::{ServeArgs, ServeHandle};
 use overdrive_cli::http_client::ApiClient;
 use overdrive_control_plane::api::SubmitWorkloadRequest;
@@ -82,7 +82,7 @@ fn read_example_toml(name: &str) -> String {
 /// `ServiceSubmitEvent` line until the stream emits a terminal event
 /// (`Stable`, `Failed`, or `Stopped`) or the response body closes.
 ///
-/// Higher-level than `submit_streaming` because the typed
+/// Higher-level than `deploy_streaming` because the typed
 /// `ServiceSubmitEvent` values are needed by S-SHCP-INT-CLI-04 to
 /// reconstruct `TerminalCondition::Stable { settled_in_ms, witness }`
 /// for the rkyv byte-equality assertion. The TOML is parsed and
@@ -101,7 +101,7 @@ async fn submit_service_and_collect_events(
     };
 
     // Project parser-side `ServiceSpec` → wire-side `ServiceSpecInput`,
-    // mirroring `commands::job::submit_streaming_service`. The wire
+    // mirroring `commands::deploy::submit_streaming_service`. The wire
     // shape preserves probe descriptors verbatim (including the
     // ADR-0058 default-TCP probe synthesised at parse time when the
     // TOML omits `[[health_check.startup]]`).
@@ -291,7 +291,7 @@ async fn given_quick_bind_service_fixture_when_submit_then_stable_settled_in_wit
     // the next test in this binary executes. The `#[serial(
     // workload_cgroup)]` attribute already prevents overlap with
     // sibling tests; this is belt-and-braces.
-    let _ = overdrive_cli::commands::job::stop(StopArgs {
+    let _ = overdrive_cli::commands::deploy::stop(StopArgs {
         id: "quick-bind".to_owned(),
         config_path: config_path(tmp.path()),
     })
@@ -359,7 +359,7 @@ async fn given_never_binds_service_fixture_when_submit_then_failed_startup_probe
         ),
     }
 
-    let _ = overdrive_cli::commands::job::stop(StopArgs {
+    let _ = overdrive_cli::commands::deploy::stop(StopArgs {
         id: "never-binds".to_owned(),
         config_path: config_path(tmp.path()),
     })
@@ -453,7 +453,7 @@ async fn given_stable_decision_when_snapshot_and_streaming_terminal_then_byte_eq
          witness={witness:?}"
     );
 
-    let _ = overdrive_cli::commands::job::stop(StopArgs {
+    let _ = overdrive_cli::commands::deploy::stop(StopArgs {
         id: "quick-bind".to_owned(),
         config_path: config_path(tmp.path()),
     })
@@ -643,7 +643,7 @@ async fn given_coinflip_as_service_fixture_when_submit_100_seeds_then_99_emit_fa
         // Clean the alloc up before the next trial so cgroup scopes do
         // not accumulate. The helper has already exited, so this is a
         // no-op converge on a Failed alloc in the common case.
-        let _ = overdrive_cli::commands::job::stop(StopArgs {
+        let _ = overdrive_cli::commands::deploy::stop(StopArgs {
             id: format!("coinflip-svc-{trial:03}"),
             config_path: cfg.clone(),
         })

--- a/crates/overdrive-cli/tests/integration/service_submit_streaming_cli_dispatch.rs
+++ b/crates/overdrive-cli/tests/integration/service_submit_streaming_cli_dispatch.rs
@@ -2,7 +2,7 @@
 //!
 //! 01-03e3 (commit `db4fccc5`) migrated the CLI consumer match arms
 //! to `ServiceSubmitEvent` but missed the submit-side dispatch path
-//! at `crates/overdrive-cli/src/commands/job.rs::submit_streaming`.
+//! at `crates/overdrive-cli/src/commands/deploy.rs::deploy_streaming`.
 //! Today (pre-fix) a Service-kind TOML falls through every Service
 //! TOML wrapped in `SubmitSpecInput::Job(spec_input)` — actually,
 //! because `JobSpecInput` is `deny_unknown_fields` and a Service
@@ -14,21 +14,21 @@
 //! This file pins the corrective contract:
 //!
 //!   * **S-SHCP-CLI-DISPATCH-01** — a Service-kind TOML fed through
-//!     `submit_streaming` MUST NOT synchronously return
+//!     `deploy_streaming` MUST NOT synchronously return
 //!     `CliError::InvalidSpec` (it routes to the new
-//!     `submit_streaming_service` path; the consumer observes
+//!     `deploy_streaming_service` path; the consumer observes
 //!     `ServiceSubmitEvent::Accepted` as the first wire line; the
 //!     test does not wait for terminal — it asserts the dispatch
 //!     reached the in-process server).
 //!   * **S-SHCP-CLI-DISPATCH-02** — a Job-kind TOML fed through the
-//!     same `submit_streaming` entrypoint MUST route to
-//!     `submit_streaming_job` and produce a Job-vocabulary summary
+//!     same `deploy_streaming` entrypoint MUST route to
+//!     `deploy_streaming_job` and produce a Job-vocabulary summary
 //!     (regression guard against accidental cross-routing).
 //!
 //! Per `crates/overdrive-cli/CLAUDE.md` § "Integration tests — no
 //! subprocess": this file spawns a real in-process control-plane
 //! server via `commands::serve::run_with_dataplane(...)` and calls
-//! `commands::job::submit_streaming(...)` directly.
+//! `commands::deploy::deploy_streaming(...)` directly.
 //!
 //! Linux-gated because the production submit path eventually drives
 //! `ExecDriver` against `/bin/sh`. The macOS `--no-run` gate
@@ -41,7 +41,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use overdrive_cli::commands::job::{StopArgs, SubmitArgs};
+use overdrive_cli::commands::deploy::{DeployArgs, StopArgs};
 use overdrive_cli::commands::serve::{ServeArgs, ServeHandle};
 use overdrive_cli::http_client::CliError;
 use serial_test::serial;
@@ -118,8 +118,8 @@ memory_bytes = 67108864
 // S-SHCP-CLI-DISPATCH-01 — Service TOML routes to ServiceSubmitEvent
 // ===========================================================================
 
-/// A Service-kind TOML fed through `submit_streaming` MUST route to
-/// `submit_streaming_service` (the `ServiceSubmitEvent` consumer
+/// A Service-kind TOML fed through `deploy_streaming` MUST route to
+/// `deploy_streaming_service` (the `ServiceSubmitEvent` consumer
 /// surface). Today the production path returns
 /// `CliError::InvalidSpec` synchronously because the Service TOML
 /// falls through to a legacy `JobSpecInput`-deserialise that
@@ -138,14 +138,14 @@ async fn cli_submit_streaming_service_routes_to_service_submit_event_consumer() 
     // `Err(CliError::InvalidSpec)` synchronously because the legacy
     // path tries `toml::from_str::<JobSpecInput>` and `[service]` is
     // an unknown field under `deny_unknown_fields`. Post-fix this
-    // routes to the new `submit_streaming_service` function which
+    // routes to the new `deploy_streaming_service` function which
     // POSTs to the in-process server; the streaming consumer awaits
     // terminal — we cap the await with a short timeout and assert
     // the dispatch reached the server (no synchronous InvalidSpec).
     let submit_cfg = cfg.clone();
     let stop_cfg = cfg.clone();
     let submit_handle = tokio::spawn(async move {
-        overdrive_cli::commands::job::submit_streaming(SubmitArgs {
+        overdrive_cli::commands::deploy::deploy_streaming(DeployArgs {
             spec: spec_path,
             config_path: submit_cfg,
         })
@@ -170,7 +170,7 @@ async fn cli_submit_streaming_service_routes_to_service_submit_event_consumer() 
     // `Stopped` so the submit task finishes. Pre-fix this is a
     // no-op (the workload was never admitted; the submit already
     // failed); post-fix it walks the Service-kind terminal path.
-    let _ = overdrive_cli::commands::job::stop(StopArgs {
+    let _ = overdrive_cli::commands::deploy::stop(StopArgs {
         id: "svc-dispatch-1".to_owned(),
         config_path: stop_cfg,
     })
@@ -225,8 +225,8 @@ async fn cli_submit_streaming_service_routes_to_service_submit_event_consumer() 
 // S-SHCP-CLI-DISPATCH-02 — Job TOML routes to JobSubmitEvent (regression)
 // ===========================================================================
 
-/// A Job-kind TOML fed through `submit_streaming` MUST route to
-/// `submit_streaming_job` (the `JobSubmitEvent` consumer surface).
+/// A Job-kind TOML fed through `deploy_streaming` MUST route to
+/// `deploy_streaming_job` (the `JobSubmitEvent` consumer surface).
 /// Regression guard against accidental cross-routing when the new
 /// Service-kind branch is added.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -237,7 +237,7 @@ async fn cli_submit_streaming_job_still_routes_to_job_submit_event_consumer() {
 
     let spec_path = write_toml(tmp.path(), "job-dispatch-1.toml", JOB_TOML);
 
-    let output = overdrive_cli::commands::job::submit_streaming(SubmitArgs {
+    let output = overdrive_cli::commands::deploy::deploy_streaming(DeployArgs {
         spec: spec_path,
         config_path: cfg,
     })

--- a/crates/overdrive-cli/tests/integration/submit_jq_pipeline.rs
+++ b/crates/overdrive-cli/tests/integration/submit_jq_pipeline.rs
@@ -1,4 +1,4 @@
-//! S-CLI-03 — Tier 3 `overdrive job submit | jq -r .spec_digest`
+//! S-CLI-03 — Tier 3 `overdrive deploy | jq -r .spec_digest`
 //! pipeline-equivalent.
 //!
 //! Per `docs/feature/cli-submit-vs-deploy-and-alloc-status/deliver/03-02`
@@ -6,7 +6,7 @@
 //!
 //! > Given a control plane is running
 //! > When the operator runs
-//! >   `overdrive job submit ./payments.toml | jq -r .spec_digest`
+//! >   `overdrive deploy ./payments.toml | jq -r .spec_digest`
 //! > Then jq's output is a single line of 64 hex characters
 //! > And the CLI exits with status 0
 //!
@@ -32,9 +32,9 @@
 //!    is_terminal=false)` — `false` simulates the pipe-redirected
 //!    stdout the real shell pipeline produces. This is the same
 //!    decision main.rs makes; the pure function is the SSOT.
-//! 3. Calling `commands::job::submit` (the JSON-ack lane) — the lane
+//! 3. Calling `commands::deploy::submit` (the JSON-ack lane) — the lane
 //!    `should_stream == false` selects.
-//! 4. Asserting on the typed `SubmitOutput.spec_digest` — a 64-char
+//! 4. Asserting on the typed `DeployOutput.spec_digest` — a 64-char
 //!    lowercase-hex SHA-256 — which is what `jq -r .spec_digest` would
 //!    extract from the real JSON response body.
 //!
@@ -52,7 +52,7 @@
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
-use overdrive_cli::commands::job::{SubmitArgs, SubmitOutput, should_stream};
+use overdrive_cli::commands::deploy::{DeployArgs, DeployOutput, should_stream};
 use overdrive_cli::commands::serve::{ServeArgs, ServeHandle};
 use overdrive_control_plane::api::IdempotencyOutcome;
 use tempfile::TempDir;
@@ -123,23 +123,23 @@ async fn pipe_redirected_submit_emits_64_char_hex_spec_digest_via_json_lane() {
 
     // Step 2 — call the lane the dispatch decision selects (JSON-ack).
     // This IS what main.rs would do under
-    //   `overdrive job submit ./payments.toml | jq -r .spec_digest`
+    //   `overdrive deploy ./payments.toml | jq -r .spec_digest`
     // — the pipe makes stdout non-TTY, `should_stream` returns false,
-    // and main.rs invokes `commands::job::submit` (which sets
+    // and main.rs invokes `commands::deploy::submit` (which sets
     // `Accept: application/json` on the request).
-    let output: SubmitOutput =
-        overdrive_cli::commands::job::submit(SubmitArgs { spec: spec_path, config_path: cfg })
+    let output: DeployOutput =
+        overdrive_cli::commands::deploy::deploy(DeployArgs { spec: spec_path, config_path: cfg })
             .await
             .expect(
-                "S-CLI-03: pipe-redirected `overdrive job submit ./payments.toml` MUST succeed — \
+                "S-CLI-03: pipe-redirected `overdrive deploy ./payments.toml` MUST succeed — \
                  the JSON-ack lane against an in-process control plane is the same wire path the \
                  shell pipeline would exercise",
             );
 
     // Step 3 — assert on the field `jq -r .spec_digest` would extract.
     // The shell pipeline would observe a single JSON object on stdout,
-    // pipe it to jq, and read 64 hex chars. The typed `SubmitOutput`
-    // is what `submit` returns from parsing the same JSON body — so
+    // pipe it to jq, and read 64 hex chars. The typed `DeployOutput`
+    // is what `deploy` returns from parsing the same JSON body — so
     // asserting on `output.spec_digest` IS asserting on what jq would
     // print.
     assert_eq!(

--- a/crates/overdrive-cli/tests/integration/submit_jq_pipeline.rs
+++ b/crates/overdrive-cli/tests/integration/submit_jq_pipeline.rs
@@ -27,12 +27,12 @@
 //!    `LocalIntentStore`, real `LocalObservationStore`, real
 //!    `ExecDriver`) — same shape as
 //!    `streaming_submit_happy_path.rs` and the JSON-ack
-//!    `job_submit.rs`.
+//!    `deploy.rs`.
 //! 2. Driving the dispatch decision through `should_stream(detach=false,
 //!    is_terminal=false)` — `false` simulates the pipe-redirected
 //!    stdout the real shell pipeline produces. This is the same
 //!    decision main.rs makes; the pure function is the SSOT.
-//! 3. Calling `commands::deploy::submit` (the JSON-ack lane) — the lane
+//! 3. Calling `commands::deploy::deploy` (the JSON-ack lane) — the lane
 //!    `should_stream == false` selects.
 //! 4. Asserting on the typed `DeployOutput.spec_digest` — a 64-char
 //!    lowercase-hex SHA-256 — which is what `jq -r .spec_digest` would
@@ -125,7 +125,7 @@ async fn pipe_redirected_submit_emits_64_char_hex_spec_digest_via_json_lane() {
     // This IS what main.rs would do under
     //   `overdrive deploy ./payments.toml | jq -r .spec_digest`
     // — the pipe makes stdout non-TTY, `should_stream` returns false,
-    // and main.rs invokes `commands::deploy::submit` (which sets
+    // and main.rs invokes `commands::deploy::deploy` (which sets
     // `Accept: application/json` on the request).
     let output: DeployOutput =
         overdrive_cli::commands::deploy::deploy(DeployArgs { spec: spec_path, config_path: cfg })

--- a/crates/overdrive-cli/tests/integration/walking_skeleton.rs
+++ b/crates/overdrive-cli/tests/integration/walking_skeleton.rs
@@ -9,7 +9,7 @@
 //!
 //!   WS-1 (§1.1) — `serve::run` spawns an in-process axum+rustls server
 //!     on an ephemeral port AND writes the resolved-port trust triple to
-//!     disk; `job::submit` POSTs `payments.toml`; the server returns
+//!     disk; `deploy::deploy` POSTs `payments.toml`; the server returns
 //!     `outcome = Inserted` and a `spec_digest` BYTE-IDENTICAL to a
 //!     locally-computed
 //!     `ContentHash::of(rkyv::to_bytes(&Job::from_submit(...)))`.
@@ -18,7 +18,7 @@
 //!     (`{mode, region, reconcilers, broker}`); `broker.dispatched > 0`
 //!     after a tick proves the reconciler runtime is alive (the ADR-0020
 //!     wiring witness — there is no `commit_index` line).
-//!   WS-3 (§1.3) — `job::submit` of a byte-identical spec returns
+//!   WS-3 (§1.3) — `deploy::deploy` of a byte-identical spec returns
 //!     `outcome = Unchanged` and `spec_digest` equal to the first
 //!     submit's digest. A different spec at the same intent key is a
 //!     conflict (HTTP 409), with an actionable error message that does
@@ -40,7 +40,7 @@ use std::path::{Path, PathBuf};
 
 use overdrive_cli::commands::alloc::{AllocStatusOutput, StatusArgs};
 use overdrive_cli::commands::cluster::StatusArgs as ClusterStatusArgs;
-use overdrive_cli::commands::job::SubmitArgs;
+use overdrive_cli::commands::deploy::DeployArgs;
 use overdrive_cli::commands::serve::{ServeArgs, ServeHandle};
 use overdrive_cli::http_client::CliError;
 use overdrive_control_plane::api::IdempotencyOutcome;
@@ -153,12 +153,12 @@ async fn walking_skeleton_ws1_ws2_ws3_post_adr_0020_wire_shape() {
     // Post-ADR-0020 the submit response carries
     // `{workload_id, spec_digest, outcome}` — no `commit_index`.
     let spec_path = write_toml(server_tmp.path(), "payments.toml", payments_toml_spec_str());
-    let submit_output = overdrive_cli::commands::job::submit(SubmitArgs {
+    let submit_output = overdrive_cli::commands::deploy::deploy(DeployArgs {
         spec: spec_path.clone(),
         config_path: server_cfg.clone(),
     })
     .await
-    .expect("job::submit");
+    .expect("deploy::deploy");
     assert_eq!(submit_output.workload_id, "payments");
     assert_eq!(submit_output.intent_key, "workloads/payments");
 
@@ -255,12 +255,12 @@ async fn walking_skeleton_ws1_ws2_ws3_post_adr_0020_wire_shape() {
     // same `spec_digest`. A different spec at the same intent key is
     // a conflict (HTTP 409), with an actionable error message that
     // does NOT leak a raw Rust panic / reqwest format.
-    let resubmit_output = overdrive_cli::commands::job::submit(SubmitArgs {
+    let resubmit_output = overdrive_cli::commands::deploy::deploy(DeployArgs {
         spec: spec_path,
         config_path: server_cfg.clone(),
     })
     .await
-    .expect("job::submit (resubmit)");
+    .expect("deploy::deploy (resubmit)");
     assert_eq!(
         resubmit_output.outcome,
         IdempotencyOutcome::Unchanged,
@@ -277,7 +277,7 @@ async fn walking_skeleton_ws1_ws2_ws3_post_adr_0020_wire_shape() {
 
     let altered_path =
         write_toml(server_tmp.path(), "payments-altered.toml", payments_altered_toml_spec_str());
-    let conflict_err = overdrive_cli::commands::job::submit(SubmitArgs {
+    let conflict_err = overdrive_cli::commands::deploy::deploy(DeployArgs {
         spec: altered_path,
         config_path: server_cfg,
     })


### PR DESCRIPTION
Renames the CLI's internal handler surface to track the `overdrive deploy <SPEC>` verb — the user-facing command was promoted to top-level in `17f633e2`, but the handler layer kept the stale `job`/`submit` naming that stayed grep-discoverable and leaked back into operator-facing docs (the trap tracked by #193). This single-cut rename (no shims) moves `commands/job.rs` → `deploy.rs`, renames `submit`/`submit_streaming` → `deploy`/`deploy_streaming` (the per-kind `deploy_streaming_{job,service}` keep the workload-kind suffix), `SubmitArgs`/`SubmitOutput`/`SubmitStreamingOutput` → `Deploy*`, and the `job_submit{,_schedule}.rs` test files → `deploy{,_schedule}.rs`, plus purges residual `job submit` / `commands/job.rs` phrasing from doc comments and both CLAUDE.md files. The `Job` subcommand (`list`/`stop`) and its handlers, the cross-crate wire types (`SubmitWorkloadRequest`, `SubmitSpecInput`, `JobSubmitEvent`), `ApiClient::submit_workload`, and the already-`workload`-prefixed render helpers are deliberately untouched. The issue's acceptance grep (`rg "job::submit|fn submit\b|SubmitArgs|SubmitOutput"`) now returns empty, and the full workspace suite passes (1868/1868). Closes #193.